### PR TITLE
Use `microsoftonline.com` instead of `windows.net`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Applications must supply a `verify` callback which accepts an `accessToken`, `re
 * `callbackURL`: URL to which Azure AD will redirect the user after obtaining authorization.
 * `resource`: [optional] the App ID URI of the web API (secured resource).
 * `tenant`: [optional] tenant domain (e.g.: contoso.onmicrosoft.com).
-* `useCommonEndpoint`: [optional] use "https://login.windows.net/common" instead of default endpoint (https://login.windows.net/{tenant}). This is typically enabled if you're using this for a Multi-tenant application in Azure AD (Default: `false`).
+* `useCommonEndpoint`: [optional] use "https://login.microsoftonline.com/common" instead of default endpoint (https://login.microsoftonline.com/{tenant}). This is typically enabled if you're using this for a Multi-tenant application in Azure AD (Default: `false`).
 
 ```javascript
 passport.use(new AzureAdOAuth2Strategy({

--- a/lib/passport-azure-ad-oauth2/strategy.js
+++ b/lib/passport-azure-ad-oauth2/strategy.js
@@ -23,7 +23,7 @@ var util = require('util')
  *   - `callbackURL`        URL to which Azure AD will redirect the user after obtaining authorization
  *   - `resource`           [optional] the App ID URI of the web API (secured resource)
  *   - `tenant`             [optional] tenant domain (e.g.: contoso.onmicrosoft.com)
- *   - `useCommonEndpoint`  [optional] Use "https://login.windows.net/common" instead of default endpoint (https://login.windows.net/{your_domain})
+ *   - `useCommonEndpoint`  [optional] Use "https://login.microsoftonline.com/common" instead of default endpoint (https://login.microsoftonline.com/{your_domain})
  *
  * Examples:
  *
@@ -51,7 +51,7 @@ function Strategy (options, verify) {
   // more details: http://msdn.microsoft.com/en-us/library/azure/dn645542.aspx
   options = options || {};
 
-  var base_url = 'https://login.windows.net/' + ((!options.useCommonEndpoint && options.tenant) || 'common');
+  var base_url = 'https://login.microsoftonline.com/' + ((!options.useCommonEndpoint && options.tenant) || 'common');
   options.authorizationURL = options.authorizationURL || base_url + '/oauth2/authorize';
   options.tokenURL = options.tokenURL || base_url + '/oauth2/token';
   
@@ -99,7 +99,7 @@ Strategy.prototype.userProfile = function (accessToken, done) {
   // waad provides user profile information in the id_token response (params.id_token).
   done(null, { provider: 'azure_ad_oauth2' });
   
-  /*this._oauth2.get('https://login.windows.net/{XYZ}/openid/userinfo', accessToken, function (err, body, res) {
+  /*this._oauth2.get('https://login.microsoftonline.com/{XYZ}/openid/userinfo', accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
   });*/
 };


### PR DESCRIPTION
Per Azure documentation, use `microsoftonline.com` instead of
`windows.net` for your base URL value.

More information: 
[Authorization Code Grant Flow](https://msdn.microsoft.com/library/azure/dn645542.aspx)