### PR TITLE
Pass decoded profile to verify callback

### DIFF
--- a/lib/passport-azure-ad-oauth2/strategy.js
+++ b/lib/passport-azure-ad-oauth2/strategy.js
@@ -2,6 +2,7 @@
  * Module dependencies.
  */
 var util = require('util')
+  , jwt = require('jsonwebtoken')
   , OAuth2Strategy = require('passport-oauth').OAuth2Strategy
   , InternalOAuthError = require('passport-oauth').InternalOAuthError;
 
@@ -55,7 +56,35 @@ function Strategy (options, verify) {
   options.authorizationURL = options.authorizationURL || base_url + '/oauth2/authorize';
   options.tokenURL = options.tokenURL || base_url + '/oauth2/token';
   
-  OAuth2Strategy.call(this, options, verify);
+  function verifyWithReq(req, accessToken, refresh_token, params, profile, done) {
+    var params = arguments[3];
+    var waadProfile = jwt.decode(params.id_token);
+    arguments[4] = waadProfile;
+    verify.apply(this, arguments);
+  }
+
+  function verifyWithoutReq (accessToken, refresh_token, params, profile, done) {
+    var params = arguments[2];
+    var waadProfile = jwt.decode(params.id_token);
+    arguments[3] = waadProfile;
+    verify.apply(this, arguments);
+  }
+
+  var verifyWithProfile = verify;
+  var arity = verify.length;
+  // Arity check to make sure verify callback is expecting params argument
+  // Otherwise keep the original verify callback
+  if (options.passReqToCallback) {
+    if (arity == 6) {
+      verifyWithProfile = verifyWithReq;
+    }
+  } else {
+    if (arity == 5) {
+      verifyWithProfile = verifyWithoutReq;
+    }
+  }
+
+  OAuth2Strategy.call(this, options, verifyWithProfile);
 
   this.name = 'azure_ad_oauth2';
   this.resource = options.resource;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   ],
   "main": "./lib/passport-azure-ad-oauth2",
   "dependencies": {
-    "passport-oauth": "1.0.x"
+    "passport-oauth": "1.0.x",
+    "jsonwebtoken": "8.5.1"
   },
   "devDependencies": {
     "mocha": "1.x.x",


### PR DESCRIPTION
Currently if we want to use user profile we need to decode it on the verify callback (and this is not an issue it's just something small)
This tries to solve that and pass the user profile already decoded to the user verify callback.
It's not implemented on the `userProfile` method but on the Strategy constructor, but I don't think this `userProfile` is used anywhere else other than to get the profile and call `verify`, hence why I'm assuming it's fine.
Regarding backwards compatibility for those decoding the `params.id_token` it should continue to work as this passes all the same params plus the user profile. 
