### PR TITLE
Clone the options object in authorizationParams

### DIFF
--- a/lib/passport-azure-ad-oauth2/strategy.js
+++ b/lib/passport-azure-ad-oauth2/strategy.js
@@ -113,7 +113,7 @@ Strategy.prototype.userProfile = function (accessToken, done) {
  * @api protected
  */
 Strategy.prototype.authorizationParams = function (options) {
-  return options;
+  return JSON.parse(JSON.stringify(options));
 };
 
 /**


### PR DESCRIPTION
Function authorizationParams returns extra Azure AD-sepecific parameters
to be included in the authorization request. Here it simply returns the
options object that is passed but the caller (passport-oauth2) then modifies the object
which can cause problems in subsequent authentication attempts. With
this change, a clone of the options object is returned, so the
modifications don't affect subsequent authentications.

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Return a clone of the options object from authenticationParams rather than the passed options object itself. This allows the caller to modify the object without affecting subsequent authentications, which is a problem I experienced using this with current passport-oauth2 package.


### References

none

### Testing

I have not provided any tests. I suppose a unit test should exercise authorizationParams and confirm that the returned object is not the object passed but has the same keys and values.

In my use, the options object is empty but it is possible that someone else depends on the current behaviour - that changes made to the options object are persistent across authentication attempts. It seems unlikely, but I can't rule it out. So, this might be a breaking change for some, though I think not if used simply with current passport and passport-oauth2 packages.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
